### PR TITLE
Fix Tidypics AJAX upload completion JSON response

### DIFF
--- a/actions/photos/image/ajax_upload_complete.php
+++ b/actions/photos/image/ajax_upload_complete.php
@@ -95,8 +95,6 @@ if ($album->new_album) {
 	}
 }
 
-$output = json_encode([
+return elgg_ok_response([
 	'batch_guid' => $batch->getGUID(),
-]);
-
-return elgg_ok_response($output, '');
+], '');


### PR DESCRIPTION
### Motivation
- Prevent double-encoding of the AJAX response so the frontend can read `json.batch_guid` and redirect correctly after upload completion.

### Description
- Return an array directly to `elgg_ok_response()` instead of a pre-encoded JSON string in `actions/photos/image/ajax_upload_complete.php`, ensuring `batch_guid` is returned as structured data.

### Testing
- Ran `php -l actions/photos/image/ajax_upload_complete.php` and a repository-wide PHP syntax lint (excluding `vendors/`) via `rg --files -g '*.php' -g '!vendors/**' | xargs -n1 php -l`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b1d9d6b4883289122374217550be2)